### PR TITLE
Handle the secure-pet-shelter PS upgrade to 9.4.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   conjur-db:
-    image: postgres:9.3
+    image: postgres:9.4
   conjur:
     image: cyberark/conjur
     command: server


### PR DESCRIPTION
It is a prerequisite for the audit atomicity.
New data type JsonB was introduced in PS9.4 and is used by the audit.